### PR TITLE
add source as argument to createDocumentSet

### DIFF
--- a/docs/api_reference/nlpql/documentset.rst
+++ b/docs/api_reference/nlpql/documentset.rst
@@ -32,6 +32,7 @@ Uses arguments to build a custom Solr query to retrieve document set. All argume
 =====================  ================  ===============================================================
 report_types           List[str]         List of report types. Corresponds to `report_types` in Solr.
 report_tags            List[str]         List of report tags. Report tags mapped to document ontology.
+source                 str OR List[str]  List of sources to map to. Use array of strings or string, separated by commas.
 filter_query           str               Use single quote (') to quote. Corresponds to Solr `fq` parameter. See `here <https://lucene.apache.org/solr/guide/7_4/common-query-parameters.html#fq-filter-query-parameter>`_.*
 query                  str               Use single quote (') to quote. Corresponds to Solr `q` parameter. See `here <https://lucene.apache.org/solr/guide/7_4/the-standard-query-parser.html#the-standard-query-parser>`_.*
 =====================  ================  ===============================================================
@@ -46,6 +47,7 @@ query                  str               Use single quote (') to quote. Correspo
          "report_types":["Discharge summary"],
          "report_tags": [],
          "filter_query": "",
+         "source": ["MIMIC","FDA Drug Labels"],
          "query":"report_text:amoxicillin"});
 
 

--- a/nlp/data_access/pipeline_config.py
+++ b/nlp/data_access/pipeline_config.py
@@ -28,7 +28,7 @@ class PipelineConfig(BaseModel):
     def __init__(self, config_type, name, terms: list=None, description='', limit=0, concept_code=-1,
                  owner='system', include_synonyms=False, include_descendants=False, include_ancestors=False,
                  report_tags: list=None, vocabulary='SNOMED', sections: list=None, report_type_query='',
-                 minimum_value=0, maximum_value=10000, case_sensitive=False, cohort: list=None,
+                 minimum_value=0, maximum_value=10000, case_sensitive=False, cohort: list=None, sources: list=None,
                  is_phenotype=False, report_types: list=None, custom_query='', filter_query='',
                  custom_arguments: dict=None, enum_list: list=None, final: bool=False, job_results: dict=None):
 
@@ -93,6 +93,10 @@ class PipelineConfig(BaseModel):
             self.job_results = dict()
         else:
             self.job_results = job_results
+        if sources is None:
+            self.sources = list()
+        else:
+            self.sources = sources
 
 
 def insert_pipeline_config(pipeline: PipelineConfig, connection_string: str):

--- a/nlp/data_access/solr_data.py
+++ b/nlp/data_access/solr_data.py
@@ -60,23 +60,30 @@ def make_url(qry, fq, sort, start, rows, solr_url):
     return url
 
 
-def make_fq(types, tags, fq, mapper_url, mapper_inst, mapper_key, report_type_query, cohort_ids, job_results_filter):
+def make_fq(types, tags, fq, mapper_url, mapper_inst, mapper_key, report_type_query, cohort_ids, job_results_filter,
+            sources):
     new_fq = fq
 
     mapped_items = get_report_type_mappings(mapper_url, mapper_inst, mapper_key)
     subjects = list()
     documents = list()
 
+    if sources and len(sources) > 0:
+        if len(new_fq) > 0:
+            new_fq += ' AND '
+        sources_fq = util.solr_source_field + ': ("' + '" OR "'.join(sources) + '")'
+        new_fq += sources_fq
+
     if types and len(types) > 0:
         if len(new_fq) > 0:
             new_fq += ' AND '
-        report_type_fq = 'report_type: ("' + '" OR "'.join(types) + '")'
+        report_type_fq = util.solr_report_type_field + ': ("' + '" OR "'.join(types) + '")'
         new_fq += report_type_fq
 
     if len(report_type_query) > 0:
         if len(new_fq) > 0:
             new_fq += ' AND '
-        report_types = 'report_type: (' + report_type_query + ')'
+        report_types = util.solr_report_type_field  + ': (' + report_type_query + ')'
         new_fq += report_types
 
     if job_results_filter:
@@ -151,7 +158,7 @@ def make_post_body(qry, fq, sort, start, rows):
 
 def query(qry, mapper_url='', mapper_inst='', mapper_key='', tags: list=None,
           sort='', start=0, rows=10, cohort_ids: list=None, types: list=None,
-          filter_query='', job_results_filters: dict=None,
+          filter_query='', job_results_filters: dict=None, sources=None,
           report_type_query='', solr_url='http://nlp-solr:8983/solr/sample'):
 
     if tags is None:
@@ -162,10 +169,12 @@ def query(qry, mapper_url='', mapper_inst='', mapper_key='', tags: list=None,
         types = list()
     if job_results_filters is None:
         job_results_filters = dict()
+    if sources is None:
+        sources = list()
 
     url = solr_url + '/select'
     fq = make_fq(types, tags, filter_query, mapper_url, mapper_inst, mapper_key, report_type_query, cohort_ids,
-                 job_results_filters)
+                 job_results_filters, sources)
     data = make_post_body(qry,  fq, sort, start, rows)
 
     print("Querying " + url)
@@ -189,7 +198,7 @@ def query(qry, mapper_url='', mapper_inst='', mapper_key='', tags: list=None,
 
 def query_doc_size(qry, mapper_url, mapper_inst, mapper_key, tags: list=None,
                    sort='', start=0, rows=10, cohort_ids: list=None, types: list=None,
-                   filter_query='', job_results_filters: dict=None,
+                   filter_query='', job_results_filters: dict=None, sources: list=None,
                    report_type_query='', solr_url='http://nlp-solr:8983/solr/sample'):
 
     if tags is None:
@@ -200,10 +209,12 @@ def query_doc_size(qry, mapper_url, mapper_inst, mapper_key, tags: list=None,
         types = list()
     if job_results_filters is None:
         job_results_filters = dict()
+    if sources is None:
+        sources = list()
     
     url = solr_url + '/select'
     fq = make_fq(types, tags, filter_query, mapper_url, mapper_inst, mapper_key, report_type_query, cohort_ids,
-                 job_results_filters)
+                 job_results_filters, sources)
     data = make_post_body(qry, fq, sort, start, rows)
 
     print("Querying to get counts " + url)

--- a/nlp/luigi_module.py
+++ b/nlp/luigi_module.py
@@ -94,7 +94,9 @@ def initialize_task_and_get_documents(pipeline_id, job_id, owner):
                                           mapper_url=util.report_mapper_url,
                                           mapper_key=util.report_mapper_key, solr_url=util.solr_url,
                                           types=pipeline_config.report_types, filter_query=pipeline_config.filter_query,
-                                          tags=pipeline_config.report_tags, report_type_query=pipeline_config.report_type_query,
+                                          tags=pipeline_config.report_tags,
+                                          report_type_query=pipeline_config.report_type_query,
+                                          sources=pipeline_config.sources,
                                           cohort_ids=pipeline_config.cohort,
                                           job_results_filters=pipeline_config.job_results)
     doc_limit = config.get_limit(total_docs, pipeline_config)
@@ -150,7 +152,7 @@ class PipelineTask(luigi.Task):
 
 if __name__ == "__main__":
     owner = "tester"
-    p_id = "10497"
+    p_id = "10521"
     the_job_id = data_access.create_new_job(
         data_access.NlpJob(job_id=-1, name="Test Phenotype", description="Test Phenotype",
                            owner=owner, status=data_access.STARTED, date_ended=None,

--- a/nlp/tasks/task_utilities.py
+++ b/nlp/tasks/task_utilities.py
@@ -154,6 +154,7 @@ class BaseTask(luigi.Task):
                                             tags=self.pipeline_config.report_tags, mapper_inst=util.report_mapper_inst,
                                             mapper_url=util.report_mapper_url, mapper_key=util.report_mapper_key,
                                             types=self.pipeline_config.report_types,
+                                            sources=self.pipeline_config.sources,
                                             filter_query=self.pipeline_config.filter_query,
                                             cohort_ids=self.pipeline_config.cohort,
                                             job_results_filters=self.pipeline_config.job_results)


### PR DESCRIPTION
**Issue number**
Fixes #72 

**Mentions**
@jduke99 

**Description**
Supports adding "source" to documentset. e.g.
```
documentset Docs:
    Clarity.createDocumentSet({
        "query":"report_text:headache OR migraine",
        "source": "MIMIC"
    });
```
OR
```
documentset Docs:
    Clarity.createDocumentSet({
        "query":"report_text:headache OR migraine",
        "source": ["MIMIC", "FDA Drug Labels"]
    });
```

**Documentation**
Yes, will be [here](https://claritynlp.readthedocs.io/en/latest/api_reference/nlpql/documentset.html).
